### PR TITLE
adjust spacing of ^<a^> tag

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,11 +13,9 @@
     <div class="text-5xl flex h-screen font-sans transition-all">
       <div class="m-auto">
         <p class="text-center">
-          Is <a
-            href="https://ping.gg"
-            class="text-ping font-bold hover:p-1 hover:bg-ping hover:text-white hover:rounded transition-all"
-            >Ping.gg
-          </a> Hiring?
+          Is 
+          <a href="https://ping.gg" class="text-ping font-bold hover:p-1 hover:bg-ping hover:text-white hover:rounded transition-all">Ping.gg</a> 
+          Hiring?
         </p>
         <br />
         <!-- ^ scuffed -->


### PR DESCRIPTION
ah that's not a good title oh well

extremely minor nitpick. the way the <a> tag is spaced now, the ping.gg link has a bit of extra room:
![image](https://user-images.githubusercontent.com/25379179/185566169-3ac2eed8-ccd7-46f5-808a-1cadfcef5583.png)

i put the <a> tag all on one line in this commit, to keep the highlight tightly around the link:
![image](https://user-images.githubusercontent.com/25379179/185566293-4f803ecc-7b46-43dc-9a96-4d6a9ee90024.png)

this is an extreme nitpick. whoops.

